### PR TITLE
WIP: Some fixes for Windows compatibility 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NATIVE_BUILD)
 		GIT_REPOSITORY https://github.com/doitsujin/dxvk.git
 		GIT_TAG v2.2
 		PATCH_COMMAND patch -f -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/dxvk-meson.patch || true
-		CONFIGURE_COMMAND meson setup <SOURCE_DIR> --cross-file ${CMAKE_CURRENT_SOURCE_DIR}/dxvk-build-linux32.txt -Dcpp_std=c++17
+		CONFIGURE_COMMAND meson setup <SOURCE_DIR> --cross-file ${CMAKE_CURRENT_SOURCE_DIR}/dxvk-build-linux32.txt -Dcpp_std=c++20
 		BUILD_COMMAND ninja src/d3d11/libdxvk_d3d11.so
 		INSTALL_COMMAND "")
 
@@ -66,7 +66,7 @@ if (NATIVE_BUILD)
 	target_link_libraries(dxhr PRIVATE
 		dxvk_d3d11 SDL2)
 	set_target_properties(dxhr PROPERTIES
-		CXX_STANDARD 17)
+		CXX_STANDARD 20)
 
 	target_link_directories(dxhr PRIVATE
 		3rdParty/fmod)
@@ -88,7 +88,7 @@ elseif (MSVC)
 
 	set_target_properties(dxhr PROPERTIES
 		OUTPUT_NAME dxhr
-		CXX_STANDARD 17)
+		CXX_STANDARD 20)
 
 	target_sources(dxhr PRIVATE
 		res/resources.rc)
@@ -131,7 +131,7 @@ else()
 	endif()
 	set_target_properties(dxhr PROPERTIES
 		OUTPUT_NAME dxhr.exe
-		CXX_STANDARD 17)
+		CXX_STANDARD 20)
 	target_sources(dxhr PRIVATE
 		res/resources.rc)
 

--- a/spinnycube.cpp
+++ b/spinnycube.cpp
@@ -1530,9 +1530,9 @@ int spinnyCube(HWND window,
 					ImGui::TableHeadersRow();
 					ImGui::TableNextRow();
 					ImGui::TableSetColumnIndex(0);
-					if (auto *vertexDecl = uiact.selectedVertexDecl) {
-						D3D11_INPUT_ELEMENT_DESC elems[vertexDecl->numAttr];
-						MakeD3DVertexElements(elems, vertexDecl->attrib, vertexDecl->numAttr, false);
+					if (auto* vertexDecl = uiact.selectedVertexDecl) {
+						std::vector<D3D11_INPUT_ELEMENT_DESC> elems(vertexDecl->numAttr);
+						MakeD3DVertexElements(elems.data(), vertexDecl->attrib, vertexDecl->numAttr, false);
 						for (uint32_t i = 0; i < vertexDecl->numAttr; i++)
 							ImGui::Text("%08x %s %d",
 								vertexDecl->attrib[i].attribKind,


### PR DESCRIPTION
This just makes some changes I observed were necessary to get the project building on Windows.

I have not tested if this code will work the same way on Linux (although I don't see any reason why it shouldn't... unless DXVK doesn't play nicely with C++20)

I still have work to do which is why this is a WIP branch. 

- Add CMakeSettings.json: This will create build configurations specifically for CMake on Visual Studio that should be accessible by other Windows users as well. Ideally we want 4 configurations in total: x86-MSVC-Debug/Release, and x86-Clang-Debug/Release. 
- Figure out a way to reliably detect the presence of Visual Studio/MSVC through CMake
