### PR TITLE
Set missingTexture to nullptr to fix windows crash

### DIFF
--- a/cdcRender/PCDX11RenderDevice.h
+++ b/cdcRender/PCDX11RenderDevice.h
@@ -113,7 +113,7 @@ public:
 	PCDX11PixelShaderTable shtab_ps_errorColor; // 10DF0
 
 	PCDX11StreamDeclCache streamDeclCache; // 1112D4
-	PCDX11Texture *missingTexture; // 1112F0
+	PCDX11Texture *missingTexture = nullptr; // 1112F0
 
 	PCDX11SimpleStaticVertexBuffer *fullScreenQuadVB; // 11156C
 	PCDX11SimpleDynamicVertexBuffer *quadVB; // 111570


### PR DESCRIPTION
On windows there is a crash on startup due to a pointer Access Violation at PCDX11StateManager::setTextureAndSampler. This is because missingTexture is uninitialized so windows will give it the value `0xcdcdcdd1` [link](https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/bebs9zyz(v=vs.100)?redirectedfrom=MSDN) this causes the null check in
CDX11RenderDevice::setTexture to be skipped